### PR TITLE
fix: address dogfood issues (encoding, broken badges, empty states)

### DIFF
--- a/src/config/urls.ts
+++ b/src/config/urls.ts
@@ -42,7 +42,8 @@ export const crestUrl = (crestAssetId?: string | null): string => {
 export const divisionCrestUrl = (division?: string | null): string | null => {
   if (!division) return null;
   const n = Number(String(division).trim());
-  return Number.isFinite(n) && n > 0 ? `${EA_DIVISION_BASE}divisioncrest${Math.trunc(n)}.png` : null;
+  // EA CDN only hosts badges for divisions 1–6; 7+ return 404
+  return Number.isFinite(n) && n > 0 && n <= 6 ? `${EA_DIVISION_BASE}divisioncrest${Math.trunc(n)}.png` : null;
 };
 
 export const reputationTierUrl = (tier?: string | null): string => {

--- a/src/pages/GlobalStats.tsx
+++ b/src/pages/GlobalStats.tsx
@@ -28,7 +28,7 @@ export default function PlayerStatisticsPage() {
   // estado
   const [players, setPlayers] = useState<PlayerStats[]>([]);
   const [clubStats, setClubStats] = useState<ClubStats | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [fetching, setFetching] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -168,7 +168,7 @@ export default function PlayerStatisticsPage() {
             </>
           ) : (
             <>
-              Clube atual: <span className="font-semibold">{groupClubIds[0] ?? "-"}</span>
+              Clube atual: <span className="font-semibold">{club?.clubName || (groupClubIds[0] ?? "-")}</span>
             </>
           )}
         </div>

--- a/src/pages/GlobalStats.tsx
+++ b/src/pages/GlobalStats.tsx
@@ -8,7 +8,7 @@ import { PlayerStatsTable } from "../components/PlayerStatsTable.tsx";
 import { API_ENDPOINTS } from "../config/urls.ts";
 
 export default function PlayerStatisticsPage() {
-  const { club } = useClub();
+  const { club, selectedClubs } = useClub();
   const fallbackClubId = club?.clubId ?? null;
 
   const [searchParams, setSearchParams] = useSearchParams();
@@ -164,7 +164,7 @@ export default function PlayerStatisticsPage() {
         <div className="text-sm text-gray-600">
           {groupClubIds.length > 1 ? (
             <>
-              Agrupando clubes: <span className="font-semibold">{groupClubIds.join(", ")}</span>
+              Agrupando clubes: <span className="font-semibold">{groupClubIds.map((id) => selectedClubs.find((c) => c.clubId === id)?.clubName || id).join(", ")}</span>
             </>
           ) : (
             <>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1092,7 +1092,7 @@ function DivisionsSelect({
    Página
 ====================== */
 export default function Home() {
-  const { club } = useClub();
+  const { club, selectedClubs } = useClub();
 
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -1436,7 +1436,7 @@ export default function Home() {
   const headerRight = hasSelection ? (
     selectedClubIds.length > 1 ? (
       <>
-        Clubes atuais: <span className="font-medium">{selectedClubIds.join(", ")}</span>
+        Clubes atuais: <span className="font-medium">{selectedClubIds.map((id) => selectedClubs.find((c) => c.clubId === id)?.clubName || id).join(", ")}</span>
       </>
     ) : (
       <>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -739,6 +739,7 @@ function MatchCard({
                   height={24}
                   className="h-8 w-8 object-contain"
                   loading="lazy"
+                  onError={(e) => (e.currentTarget.style.display = 'none')}
                 />
               )}
               <div className="w-10 shrink-0 flex justify-center overflow-visible">
@@ -813,6 +814,7 @@ function MatchCard({
                   height={24}
                   className="h-8 w-8 object-contain"
                   loading="lazy"
+                  onError={(e) => (e.currentTarget.style.display = 'none')}
                 />
               )}
               <div className="w-10 shrink-0 flex justify-end overflow-visible">
@@ -857,6 +859,7 @@ function MatchCard({
                     height={20}
                     className="h-5 w-5 object-contain"
                     loading="lazy"
+                    onError={(e) => (e.currentTarget.style.display = 'none')}
                   />
                 </div>
               )}
@@ -876,6 +879,7 @@ function MatchCard({
                     height={20}
                     className="h-5 w-5 object-contain"
                     loading="lazy"
+                    onError={(e) => (e.currentTarget.style.display = 'none')}
                   />
                 </div>
               )}
@@ -1436,7 +1440,7 @@ export default function Home() {
       </>
     ) : (
       <>
-        Clube atual: <span className="font-medium">{selectedClubIds[0]}</span>
+        Clube atual: <span className="font-medium">{fallbackClubName || selectedClubIds[0]}</span>
       </>
     )
   ) : (

--- a/src/pages/PlayerAttributes.tsx
+++ b/src/pages/PlayerAttributes.tsx
@@ -304,7 +304,7 @@ export default function PlayerAttributesPage() {
                     {/* Base: lista de atributos */}
                     <Card>
                         <h3 className="text-base font-semibold mb-3">Atributos — {base?.playerName ?? "—"}</h3>
-                        {base?.statistics ? (
+                        {base?.statistics && Object.values(base.statistics).some((v) => v && v !== 0) ? (
                             <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 text-sm text-gray-700">
                                 {(Object.keys(ATTR_LABELS) as (keyof PlayerMatchStats)[]).map((key) => (
                                     <li key={String(key)} className="col-span-1">
@@ -316,7 +316,9 @@ export default function PlayerAttributesPage() {
                                 ))}
                             </ul>
                         ) : (
-                            <div className="text-sm text-gray-600">Sem snapshot de atributos para este jogador.</div>
+                            <div className="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg p-3">
+                                Dados de atributos não disponíveis para este jogador.
+                            </div>
                         )}
                     </Card>
 
@@ -326,7 +328,7 @@ export default function PlayerAttributesPage() {
                             Comparação — {compareMode === "media" ? "Média do clube" : rows.find((r) => String(r.playerId) === String(comparePlayerId))?.playerName ?? "—"}
                         </h3>
 
-                        {compare ? (
+                        {compare && Object.values(compare).some((v) => v && v !== 0) ? (
                             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                                 {(Object.keys(ATTR_LABELS) as (keyof PlayerMatchStats)[]).map((key) => {
                                     const mine = clamp01to100(Number((base?.statistics as any)?.[key] ?? 0));

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,8 +1,43 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../config/urls.ts';
 
+/**
+ * Repair double-encoded UTF-8 strings returned by the backend.
+ * E.g. "TrovÃ£o" (Latin-1 interpretation of UTF-8 bytes) → "Trovão"
+ */
+function fixDoubleEncodedUtf8(str: string): string {
+    try {
+        // Only process strings that contain bytes in the 0x80–0xFF range (sign of double-encoding)
+        if (!/[\x80-\xff]/.test(str)) return str;
+        const bytes = new Uint8Array([...str].map(c => c.charCodeAt(0)));
+        return new TextDecoder('utf-8').decode(bytes);
+    } catch {
+        return str;
+    }
+}
+
+function fixStringsDeep(obj: any): any {
+    if (typeof obj === 'string') return fixDoubleEncodedUtf8(obj);
+    if (Array.isArray(obj)) return obj.map(fixStringsDeep);
+    if (obj !== null && typeof obj === 'object') {
+        const out: any = {};
+        for (const key of Object.keys(obj)) {
+            out[key] = fixStringsDeep(obj[key]);
+        }
+        return out;
+    }
+    return obj;
+}
+
 const api = axios.create({
     baseURL: API_BASE_URL,
+});
+
+api.interceptors.response.use((response) => {
+    if (response.data && typeof response.data === 'object') {
+        response.data = fixStringsDeep(response.data);
+    }
+    return response;
 });
 
 export default api;


### PR DESCRIPTION
## Summary

- **Encoding fix**: Added axios response interceptor to repair double-encoded UTF-8 strings from the backend (e.g., "TrovÃ£o" → "Trovão")
- **Broken division badges**: `divisionCrestUrl()` now returns `null` for divisions > 6 (EA CDN 404s), plus `onError` handlers hide broken `<img>` tags
- **Club name display**: Partidas and Estatísticas pages now show the club name instead of raw numeric ID
- **Estatísticas empty state**: Fixed initial loading state so data auto-loads on first navigation
- **Player attributes zeros**: Shows informational banner when all attribute values are zero instead of a misleading grid of zeros

## Backend changes needed (flagged)

1. Division data returns old 1-10 numbering — needs mapping to new system (1-5 + elite)
2. API serves double-encoded UTF-8 — should fix at source so frontend interceptor becomes unnecessary
3. `/api/clubs/{id}/players/attributes` returns all-zero attribute data
